### PR TITLE
Various updates, plus attempted fix for #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ bin/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/.vscode/
+/test-20*.log

--- a/src/serilogj/LoggerConfiguration.java
+++ b/src/serilogj/LoggerConfiguration.java
@@ -129,6 +129,6 @@ public class LoggerConfiguration {
 				additionalDestructuringPolicies.toArray(new IDestructuringPolicy[0]));
 		MessageTemplateProcessor processor = new MessageTemplateProcessor(converter);
 
-		return new Logger(processor, minimumLevel, sink, enrichers.toArray(new ILogEventEnricher[0]), levelSwitch);
+		return new Logger(processor, minimumLevel, sink, enrichers.toArray(new ILogEventEnricher[0]), levelSwitch, true);
 	}
 }

--- a/src/serilogj/core/sinks/SafeAggregateSink.java
+++ b/src/serilogj/core/sinks/SafeAggregateSink.java
@@ -1,5 +1,7 @@
 package serilogj.core.sinks;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.*;
 import serilogj.events.*;
 import serilogj.core.*;
@@ -19,7 +21,7 @@ import serilogj.debugging.SelfLog;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public class SafeAggregateSink implements ILogEventSink {
+public class SafeAggregateSink implements ILogEventSink, Closeable {
 	private ArrayList<ILogEventSink> sinks;
 
 	public SafeAggregateSink(ILogEventSink[] sinks) {
@@ -46,6 +48,15 @@ public class SafeAggregateSink implements ILogEventSink {
 				sink.emit(logEvent);
 			} catch (RuntimeException ex) {
 				SelfLog.writeLine("Caught exception %s while emitting to sink %s.", ex.getMessage(), sink);
+			}
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		for (ILogEventSink sink : sinks) {
+			if (sink instanceof java.io.Closeable) {
+				((java.io.Closeable) sink).close();
 			}
 		}
 	}

--- a/src/serilogj/sinks/periodicbatching/BatchedConnectionStatus.java
+++ b/src/serilogj/sinks/periodicbatching/BatchedConnectionStatus.java
@@ -6,8 +6,8 @@ public class BatchedConnectionStatus {
 	private static final Duration MinimumBackoffPeriod = Duration.ofSeconds(5);
 	private static final Duration MaximumBackoffInterval = Duration.ofMinutes(10);
 
-	private static final int FailuresBeforeDroppingBatch = 4;
-	private static final int FailuresBeforeDroppingQueue = 6;
+	private static final int FailuresBeforeDroppingBatch = 8;
+	private static final int FailuresBeforeDroppingQueue = 10;
 
 	private Duration period;
 

--- a/src/serilogj/sinks/seq/SeqSink.java
+++ b/src/serilogj/sinks/seq/SeqSink.java
@@ -149,7 +149,7 @@ public class SeqSink extends PeriodicBatchingSink {
 				levelSwitch = new LoggingLevelSwitch(level);
 			}
 		} catch (IOException e) {
-			SelfLog.writeLine("Error sending events to seq, exception %s", e.getMessage());
+			SelfLog.writeLine("Error sending events to Seq, exception %s", e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
Hello, there!

Let me prefix this by saying that I probably have no idea what I'm doing ;-) ... I was pleasantly surprised how easy it was to get up and running, but my Java knowledge is shallow, so apologies in advance if I've shot off in the wrong direction.

After a note from @mjnorman this morning I thought I'd take a look at #5, and seeing no obvious problem with the code, decided based on the documentation I found that `ScheduledExecutorService` - which uses thread pooling - might avoid whatever is causing the orphaned thread leak.

In the process, I had to debug through getting the "close" logic to run, and ironed out what looked like a couple of issues along the way.

Notes below:

 - Slightly more complete/pedagogical example
 - Close/flush sinks on `Log.closeAndFlush()` or `Logger.close()`
 - Extend the failed-batch retry interval to the expected 10 minutes (parallel of a fix made recently in Serilog)
 - Switch from Timer and TimerTask to the more modern `ScheduledExecutorService` in an attempt to fix #5 (did not attempt a repro)
 - Don't use double-checked locking to init `PeriodicBatchingSink` - just schedule `execute()` immediately at startup

I haven't tested this apart from via `JavaConsole.main()`:

![image](https://user-images.githubusercontent.com/342712/28764833-f3e4c160-760a-11e7-8c39-12f121f31094.png)

Happy to revert/change direction/cherry-pick changes if it helps.

Cheers,
Nick